### PR TITLE
1229 fix.

### DIFF
--- a/shakemap_aqms/coremods/aqms_db2xml.py
+++ b/shakemap_aqms/coremods/aqms_db2xml.py
@@ -11,7 +11,7 @@ from shakemap.coremods.base import CoreModule
 from shakemap.utils.config import get_config_paths
 from shakemap_aqms.util import get_aqms_config
 from shakemap_aqms.util import dataframe_to_xml
-from shakelib.rupture.origin import Origin
+from impactutils.rupture.origin import Origin
 
 
 class AQMSDb2XMLModule(CoreModule):

--- a/shakemap_aqms/coremods/aqms_eq2xml.py
+++ b/shakemap_aqms/coremods/aqms_eq2xml.py
@@ -8,7 +8,7 @@ import os.path
 from shakemap.coremods.base import CoreModule
 from shakemap.utils.config import get_config_paths
 from shakemap_aqms.util import get_aqms_config, get_eqinfo
-from shakelib.rupture.origin import write_event_file
+from impactutils.rupture.origin import write_event_file
 
 
 class AQMSEq2XMLModule(CoreModule):


### PR DESCRIPTION
updated the following.

modify the shakemap-aqms .py files that call for import Origin,
aqms_db2xml.py orig:
from shakelib.rupture.origin import Origin
new:
from impactutils.rupture.origin import Origin

aqms_eq2xml.py orig:
from shakelib.rupture.origin import write_event_file
new:
from impactutils.rupture.origin import write_event_file